### PR TITLE
Batch Mode + Maintain Aspect Ratio + Multi-GPU Random Seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Changes from pftq:
 - Added seed synchronization code to allow random seed with multi-GPU.
 - Added batch_size parameter to allow multiple videos to generate without reloading the model.
+- Friendlier filenames with date, seed, cfg, steps, and other details in front.
+<hr>
 
 <p align="center">
   <img src="assets/logo2.png" alt="SkyReels Logo" width="50%">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Changes from pftq:
 - Added seed synchronization code to allow random seed with multi-GPU.
+- Added image broadcast/synchronization to avoid potential sync issues in multi-GPU.
 - Added batch_size parameter to allow multiple videos to generate without reloading the model.
 - Added preserve_image_aspect_ratio parameter to allow preserving original image aspect ratio.
 - Friendlier filenames with date, seed, cfg, steps, and other details in front.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Changes from pftq:
 - Added seed synchronization code to allow random seed with multi-GPU.
 - Added image broadcast/synchronization to avoid potential sync issues in multi-GPU.
-- Added batch_size parameter to allow multiple videos to generate without reloading the model.
+- Added batch_size parameter to allow multiple videos to generate without reloading the model, which takes about 20 min on multi-gpu so this saves a lot of time.
 - Added preserve_image_aspect_ratio parameter to allow preserving original image aspect ratio.
 - Friendlier filenames with date, seed, cfg, steps, and other details in front.
 <hr>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,33 @@
 - Added image broadcast/synchronization to avoid potential sync issues in multi-GPU.
 - Added batch_size parameter to allow multiple videos to generate without reloading the model, which takes about 20 min on multi-gpu so this saves a lot of time.
 - Added preserve_image_aspect_ratio parameter to allow preserving original image aspect ratio.
+- Exposed negative_prompt to allow that to be changed/overwritten.
 - Friendlier filenames with date, seed, cfg, steps, and other details in front.
+
+Easy install instructions for those using Runpod like me:
+```
+#create once on new pod
+export HF_HOME=/workspace/
+export TZ=America/Los_Angeles
+python -m venv venv
+git clone https://github.com/pftq/SkyReels-V2_Improvements
+mv SkyReels-V2_Improvements SkyReels-V2
+cd /workspace/SkyReels-V2
+source /workspace/venv/bin/activate
+pip install torch==2.5.1
+pip install --upgrade wheel setuptools
+pip install packaging
+pip install -r requirements.txt --no-build-isolation
+pip install "huggingface_hub[cli]"
+huggingface-cli download Skywork/SkyReels-V2-DF-14B-540P --local-dir ./SkyReels-V2-DF-14B-540P
+deactivate
+
+#always run at the start to use persisting drive
+export HF_HOME=/workspace/
+export TZ=America/Los_Angeles
+source /workspace/venv/bin/activate
+cd /workspace/SkyReels-V2
+```
 
 Example prompt (multi-GPU):
 ```
@@ -21,6 +47,7 @@ torchrun --nproc_per_node=2 generate_video_df.py \
   --preserve_image_aspect_ratio \
   --image "image.jpg" \
   --prompt "" \
+  --negative_prompt "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards" \
   --addnoise_condition 20 \
   --use_usp \
   --offload
@@ -42,9 +69,13 @@ python3 generate_video_df.py \
   --preserve_image_aspect_ratio \
   --image "image.jpg" \
   --prompt "" \
+  --negative_prompt "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards" \
   --addnoise_condition 20 \
   --offload
 ```
+
+Change "DF" to "I2V' or "T2V" accordingly if you don't want to use the infinite length version of the model.
+
 <hr>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - Added image broadcast/synchronization to avoid potential sync issues in multi-GPU.
 - Added batch_size parameter to allow multiple videos to generate without reloading the model, which takes about 20 min on multi-gpu so this saves a lot of time.
 - Added preserve_image_aspect_ratio parameter to allow preserving original image aspect ratio.
+- Fixed DF script not resize-cropping the image (I2V script does it but DF is missing the code).
 - Exposed negative_prompt to allow that to be changed/overwritten.
 - Friendlier filenames with date, seed, cfg, steps, and other details in front.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Changes from pftq:
+- Added seed synchronization code to allow random seed with multi-GPU.
+- Added batch_size parameter to allow multiple videos to generate without reloading the model.
+
 <p align="center">
   <img src="assets/logo2.png" alt="SkyReels Logo" width="50%">
 </p>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@
 - Added batch_size parameter to allow multiple videos to generate without reloading the model, which takes about 20 min on multi-gpu so this saves a lot of time.
 - Added preserve_image_aspect_ratio parameter to allow preserving original image aspect ratio.
 - Friendlier filenames with date, seed, cfg, steps, and other details in front.
+
+Example prompt (multi-GPU):
+```
+model_id=Skywork/SkyReels-V2-DF-14B-540P
+torchrun --nproc_per_node=2 generate_video_df.py \
+  --model_id ${model_id} \
+  --resolution 540P \
+  --ar_step 0 \
+  --base_num_frames 97 \
+  --num_frames 257 \
+  --overlap_history 17 \
+  --inference_steps 50 \
+  --guidance_scale 6 \
+  --batch_size 10 \
+  --preserve_image_aspect_ratio \
+  --image "image.jpg" \
+  --prompt "" \
+  --addnoise_condition 20 \
+  --use_usp \
+  --offload
+```
 <hr>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ cd /workspace/SkyReels-V2
 Example prompt (multi-GPU):
 ```
 model_id=Skywork/SkyReels-V2-DF-14B-540P
-torchrun --nproc_per_node=2 generate_video_df.py \
+gpu_count=2
+torchrun --nproc_per_node=${gpu_count} generate_video_df.py \
   --model_id ${model_id} \
   --resolution 540P \
   --ar_step 0 \

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ pip install torch==2.5.1
 pip install --upgrade wheel setuptools
 pip install packaging
 pip install -r requirements.txt --no-build-isolation
-pip install "huggingface_hub[cli]"
-huggingface-cli download Skywork/SkyReels-V2-DF-14B-540P --local-dir ./SkyReels-V2-DF-14B-540P
 deactivate
 
 #always run at the start to use persisting drive

--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ torchrun --nproc_per_node=2 generate_video_df.py \
   --use_usp \
   --offload
 ```
+
+Single GPU:
+```
+model_id=Skywork/SkyReels-V2-DF-14B-540P
+python3 generate_video_df.py \
+  --model_id ${model_id} \
+  --resolution 540P \
+  --ar_step 0 \
+  --base_num_frames 97 \
+  --num_frames 257 \
+  --overlap_history 17 \
+  --inference_steps 50 \
+  --guidance_scale 6 \
+  --batch_size 10 \
+  --preserve_image_aspect_ratio \
+  --image "image.jpg" \
+  --prompt "" \
+  --addnoise_condition 20 \
+  --offload
+```
 <hr>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Changes from pftq:
 - Added seed synchronization code to allow random seed with multi-GPU.
 - Added batch_size parameter to allow multiple videos to generate without reloading the model.
+- Added preserve_image_aspect_ratio parameter to allow preserving original image aspect ratio.
 - Friendlier filenames with date, seed, cfg, steps, and other details in front.
 <hr>
 

--- a/generate_video.py
+++ b/generate_video.py
@@ -154,6 +154,10 @@ if __name__ == "__main__":
         prompt_input = prompt_enhancer(prompt_input)
         print(f"enhanced prompt: {prompt_input}")
 
+
+    #20250422 pftq: Set preferred linear algebra backend to avoid cuSOLVER issues
+    torch.backends.cuda.preferred_linalg_library("default")  # or try "magma" if available
+    
     for idx in range(args.batch_size): # 20250422 pftq: implemented --batch_size
         if local_rank == 0:
             print(f"Generating video {idx+1} of {args.batch_size}")

--- a/generate_video.py
+++ b/generate_video.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
 
     local_rank = 0
     if args.use_usp:
+        assert not args.prompt_enhancer, "`--prompt_enhancer` is not allowed if using `--use_usp`. We recommend running the skyreels_v2_infer/pipelines/prompt_enhancer.py script first to generate enhanced prompt before enabling the `--use_usp` parameter."
         from xfuser.core.distributed import initialize_model_parallel, init_distributed_environment
         import torch.distributed as dist
 

--- a/generate_video.py
+++ b/generate_video.py
@@ -230,7 +230,10 @@ if __name__ == "__main__":
             #video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
             
             # 20250422 pftq: more useful filename
-            video_out_file = f"{current_time}_cfg{args.guidance_scale}_steps{args.inference_steps}_seed{args.seed}_{args.prompt[:100].replace('/','')}_{idx}.mp4" 
+            gpucount = ""
+            if args.use_usp and dist.get_world_size():
+                gpucount = "_"+dist.get_world_size()+"xGPU"
+            video_out_file = f"{current_time}_skyreels2_cfg{args.guidance_scale}_steps{args.inference_steps}_seed{args.seed}{gpucount}_{args.prompt[:100].replace('/','')}_{idx}.mp4" 
             
             output_path = os.path.join(save_dir, video_out_file)
             imageio.mimwrite(output_path, video_frames, fps=args.fps, quality=8, output_params=["-loglevel", "error"])

--- a/generate_video.py
+++ b/generate_video.py
@@ -170,7 +170,7 @@ if __name__ == "__main__":
 
                 #20250422 pftq: Always broadcast seed to ensure consistency
                 if local_rank == 0:
-                    if args.seed == -1 or idx > 0:
+                    if args.seed == -1 or args.seed is None or idx > 0:
                         args.seed = int(random.randrange(4294967294))
                 seed_tensor = torch.tensor(args.seed, dtype=torch.int64, device="cuda")
                 dist.broadcast(seed_tensor, src=0)

--- a/generate_video.py
+++ b/generate_video.py
@@ -8,10 +8,12 @@ import imageio
 import torch
 from diffusers.utils import load_image
 
+from PIL import Image  #20250422 pftq: Added for image resizing and cropping
+import numpy as np  #20250422 pftq: Added for seed synchronization
+
 from skyreels_v2_infer.modules import download_model
 from skyreels_v2_infer.pipelines import Image2VideoPipeline
 from skyreels_v2_infer.pipelines import PromptEnhancer
-from skyreels_v2_infer.pipelines import resizecrop
 from skyreels_v2_infer.pipelines import Text2VideoPipeline
 
 MODEL_ID_CONFIG = {
@@ -41,37 +43,28 @@ if __name__ == "__main__":
     parser.add_argument("--use_usp", action="store_true")
     parser.add_argument("--offload", action="store_true")
     parser.add_argument("--fps", type=int, default=24)
-    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=-1)
     parser.add_argument(
         "--prompt",
         type=str,
         default="A serene lake surrounded by towering mountains, with a few swans gracefully gliding across the water and sunlight dancing on the surface.",
     )
     parser.add_argument("--prompt_enhancer", action="store_true")
+
+    parser.add_argument("--batch_size", type=int, default=1) # 20250422 pftq: Batch functionality to avoid reloading the model each video
+    parser.add_argument("--preserve_image_aspect_ratio", action="store_true")  # 20250422 pftq: Avoid resizing
+    parser.add_argument("--negative_prompt", type=str, default="Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards") # 20250422 pftq: expose negative prompt
+    
     args = parser.parse_args()
 
     args.model_id = download_model(args.model_id)
     print("model_id:", args.model_id)
 
-    assert (args.use_usp and args.seed is not None) or (not args.use_usp), "usp mode need seed"
-    if args.seed is None:
-        random.seed(time.time())
-        args.seed = int(random.randrange(4294967294))
+    #20250422 pftq: unneeded with seed synchronization code
+    #assert (args.use_usp and args.seed is not None) or (not args.use_usp), "usp mode need seed"
 
-    if args.resolution == "540P":
-        height = 544
-        width = 960
-    elif args.resolution == "720P":
-        height = 720
-        width = 1280
-    else:
-        raise ValueError(f"Invalid resolution: {args.resolution}")
-
-    image = load_image(args.image).convert("RGB") if args.image else None
-    negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
     local_rank = 0
     if args.use_usp:
-        assert not args.prompt_enhancer, "`--prompt_enhancer` is not allowed if using `--use_usp`. We recommend running the skyreels_v2_infer/pipelines/prompt_enhancer.py script first to generate enhanced prompt before enabling the `--use_usp` parameter."
         from xfuser.core.distributed import initialize_model_parallel, init_distributed_environment
         import torch.distributed as dist
 
@@ -87,6 +80,51 @@ if __name__ == "__main__":
             ring_degree=1,
             ulysses_degree=dist.get_world_size(),
         )
+
+    if args.resolution == "540P":
+        height = 544
+        width = 960
+    elif args.resolution == "720P":
+        height = 720
+        width = 1280
+    else:
+        raise ValueError(f"Invalid resolution: {args.resolution}")
+
+    #image = load_image(args.image).convert("RGB") if args.image else None
+
+    #20250422 pftq: Add error handling for image loading, aspect ratio preservation, and multi-GPU synchronization
+    image = None
+    if args.image:
+        if local_rank == 0:
+            try:
+                image = load_image(args.image).convert("RGB")
+
+                # 20250422 pftq: option to preserve image aspect ratio
+                if args.preserve_image_aspect_ratio:
+                    img_width, img_height = image.size
+                    height = int(width / img_width * img_height)
+            except Exception as e:
+                raise ValueError(f"Failed to load or process image: {e}")
+                
+        if args.use_usp:
+            # Broadcast image to other ranks
+            image_data = torch.tensor(np.array(image), dtype=torch.uint8, device="cuda") if image is not None else None
+            if local_rank == 0:
+                dist.broadcast(image_data, src=0)
+            else:
+                image_data = torch.empty((height, width, 3), dtype=torch.uint8, device="cuda")
+                dist.broadcast(image_data, src=0)
+                image = Image.fromarray(image_data.cpu().numpy())
+
+            #20250422 pftq: Broadcast height and width to ensure consistency
+            height_tensor = torch.tensor(height, dtype=torch.int64, device="cuda")
+            width_tensor = torch.tensor(width, dtype=torch.int64, device="cuda")
+            dist.broadcast(height_tensor, src=0)
+            dist.broadcast(width_tensor, src=0)
+            height = height_tensor.item()
+            width = width_tensor.item()
+
+    negative_prompt = args.negative_prompt # 20250422 pftq: allow editable negative prompt
 
     prompt_input = args.prompt
     if args.prompt_enhancer and args.image is None:
@@ -110,41 +148,78 @@ if __name__ == "__main__":
         pipe = Image2VideoPipeline(
             model_path=args.model_id, dit_path=args.model_id, use_usp=args.use_usp, offload=args.offload
         )
-        args.image = load_image(args.image)
-        image_width, image_height = args.image.size
-        if image_height > image_width:
-            height, width = width, height
-        args.image = resizecrop(args.image, height, width)
 
     prompt_input = args.prompt
     if args.prompt_enhancer and image is not None:
         prompt_input = prompt_enhancer(prompt_input)
         print(f"enhanced prompt: {prompt_input}")
 
-    kwargs = {
-        "prompt": prompt_input,
-        "negative_prompt": negative_prompt,
-        "num_frames": args.num_frames,
-        "num_inference_steps": args.inference_steps,
-        "guidance_scale": args.guidance_scale,
-        "shift": args.shift,
-        "generator": torch.Generator(device="cuda").manual_seed(args.seed),
-        "height": height,
-        "width": width,
-    }
+    for idx in range(args.batch_size): # 20250422 pftq: implemented --batch_size
+        if local_rank == 0:
+            print(f"Generating video {idx+1} of {args.batch_size}")
 
-    if image is not None:
-        kwargs["image"] = args.image.convert("RGB")
+        #20250422 pftq: Synchronize seed across all ranks
+        if args.use_usp:
+            try:
+                #20250422 pftq: Synchronize ranks before seed broadcasting
+                dist.barrier()
 
-    save_dir = os.path.join("result", args.outdir)
-    os.makedirs(save_dir, exist_ok=True)
+                #20250422 pftq: Always broadcast seed to ensure consistency
+                if local_rank == 0:
+                    if args.seed == -1 or idx > 0:
+                        args.seed = int(random.randrange(4294967294))
+                seed_tensor = torch.tensor(args.seed, dtype=torch.int64, device="cuda")
+                dist.broadcast(seed_tensor, src=0)
+                args.seed = seed_tensor.item()
 
-    with torch.cuda.amp.autocast(dtype=pipe.transformer.dtype), torch.no_grad():
-        print(f"infer kwargs:{kwargs}")
-        video_frames = pipe(**kwargs)[0]
+                #20250422 pftq: Synchronize ranks after seed broadcasting
+                dist.barrier()
+            except Exception as e:
+                print(f"[Rank {local_rank}] Seed broadcasting error: {e}")
+                dist.destroy_process_group()
+                raise
 
-    if local_rank == 0:
-        current_time = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
-        video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
-        output_path = os.path.join(save_dir, video_out_file)
-        imageio.mimwrite(output_path, video_frames, fps=args.fps, quality=8, output_params=["-loglevel", "error"])
+        else:
+            #20250422 pftq: Single GPU seed initialization
+            if args.seed == -1 or idx > 0:
+                args.seed = int(random.randrange(4294967294))
+
+        #20250422 pftq: Set seeds for reproducibility
+        random.seed(args.seed)
+        np.random.seed(args.seed)
+        torch.manual_seed(args.seed)
+        torch.cuda.manual_seed_all(args.seed)
+        
+        kwargs = {
+            "prompt": prompt_input,
+            "negative_prompt": negative_prompt,
+            "num_frames": args.num_frames,
+            "num_inference_steps": args.inference_steps,
+            "guidance_scale": args.guidance_scale,
+            "shift": args.shift,
+            "generator": torch.Generator(device="cuda").manual_seed(args.seed),
+            "height": height,
+            "width": width,
+        }
+    
+        if image is not None:
+            #kwargs["image"] = load_image(args.image).convert("RGB") 
+            # 20250422 pftq: redundant reloading of the image
+            kwargs["image"] = image
+    
+        save_dir = os.path.join("result", args.outdir)
+        os.makedirs(save_dir, exist_ok=True)
+    
+        with torch.cuda.amp.autocast(dtype=pipe.transformer.dtype), torch.no_grad():
+            print(f"infer kwargs:{kwargs}")
+            video_frames = pipe(**kwargs)[0]
+    
+        if local_rank == 0:
+            current_time = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
+            #video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
+            
+            # 20250422 pftq: more useful filename
+            video_out_file = f"{current_time}_cfg{args.guidance_scale}_steps{args.inference_steps}_seed{args.seed}_{args.prompt[:100].replace('/','')}_{idx}.mp4" 
+            
+            output_path = os.path.join(save_dir, video_out_file)
+            imageio.mimwrite(output_path, video_frames, fps=args.fps, quality=8, output_params=["-loglevel", "error"])

--- a/generate_video.py
+++ b/generate_video.py
@@ -14,6 +14,7 @@ import numpy as np  #20250422 pftq: Added for seed synchronization
 from skyreels_v2_infer.modules import download_model
 from skyreels_v2_infer.pipelines import Image2VideoPipeline
 from skyreels_v2_infer.pipelines import PromptEnhancer
+from skyreels_v2_infer.pipelines import resizecrop
 from skyreels_v2_infer.pipelines import Text2VideoPipeline
 
 MODEL_ID_CONFIG = {
@@ -104,6 +105,11 @@ if __name__ == "__main__":
                 if args.preserve_image_aspect_ratio:
                     img_width, img_height = image.size
                     height = int(width / img_width * img_height)
+                else:
+                    image_width, image_height = image.size
+                    if image_height > image_width:
+                        height, width = width, height
+                    image = resizecrop(image, height, width)
             except Exception as e:
                 raise ValueError(f"Failed to load or process image: {e}")
                 

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":
 
     local_rank = 0
     if args.use_usp:
+        assert not args.prompt_enhancer, "`--prompt_enhancer` is not allowed if using `--use_usp`. We recommend running the skyreels_v2_infer/pipelines/prompt_enhancer.py script first to generate enhanced prompt before enabling the `--use_usp` parameter."
         from xfuser.core.distributed import initialize_model_parallel, init_distributed_environment
         import torch.distributed as dist
 

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -11,6 +11,7 @@ import numpy as np  #20250422 pftq: Added for seed synchronization
 
 from skyreels_v2_infer import DiffusionForcingPipeline
 from skyreels_v2_infer.modules import download_model
+from skyreels_v2_infer.pipelines import resizecrop
 from skyreels_v2_infer.pipelines import PromptEnhancer
 
 if __name__ == "__main__":
@@ -108,6 +109,11 @@ if __name__ == "__main__":
                 if args.preserve_image_aspect_ratio:
                     img_width, img_height = image.size
                     height = int(width / img_width * img_height)
+                else:
+                    image_width, image_height = image.size
+                    if image_height > image_width:
+                        height, width = width, height
+                    image = resizecrop(image, height, width)
             except Exception as e:
                 raise ValueError(f"Failed to load or process image: {e}")
                 

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
     
     parser.add_argument("--batch_size", type=int, default=1) # 20250422 pftq: Batch functionality to avoid reloading the model each video
     parser.add_argument("--preserve_image_aspect_ratio", action="store_true")  # 20250422 pftq: Avoid resizing
+    parser.add_argument("--negative_prompt", type=str, default="Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards") # 20250422 pftq: expose negative prompt
     
     args = parser.parse_args()
 
@@ -127,7 +128,7 @@ if __name__ == "__main__":
             height = height_tensor.item()
             width = width_tensor.item()
 
-    negative_prompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+    negative_prompt = args.negative_prompt # 20250422 pftq: allow editable negative prompt
 
     save_dir = os.path.join("result", args.outdir)
     os.makedirs(save_dir, exist_ok=True)

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -155,6 +155,10 @@ if __name__ == "__main__":
     if args.causal_attention:
         pipe.transformer.set_ar_attention(args.causal_block_size)
 
+
+    #20250422 pftq: Set preferred linear algebra backend to avoid cuSOLVER issues
+    torch.backends.cuda.preferred_linalg_library("default")  # or try "magma" if available
+    
     for idx in range(args.batch_size): # 20250422 pftq: implemented --batch_size
         if local_rank == 0:
             print(f"prompt:{prompt_input}")

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -3,10 +3,11 @@ import gc
 import os
 import random
 import time
-
-import imageio
 import torch
 from diffusers.utils import load_image
+import imageio
+from PIL import Image  #20250422 pftq: Added for image resizing and cropping
+import numpy as np  #20250422 pftq: Added for seed synchronization
 
 from skyreels_v2_infer import DiffusionForcingPipeline
 from skyreels_v2_infer.modules import download_model
@@ -32,22 +33,42 @@ if __name__ == "__main__":
     parser.add_argument("--use_usp", action="store_true")
     parser.add_argument("--offload", action="store_true")
     parser.add_argument("--fps", type=int, default=24)
-    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=-1)
     parser.add_argument(
         "--prompt",
         type=str,
         default="A woman in a leather jacket and sunglasses riding a vintage motorcycle through a desert highway at sunset, her hair blowing wildly in the wind as the motorcycle kicks up dust, with the golden sun casting long shadows across the barren landscape.",
     )
     parser.add_argument("--prompt_enhancer", action="store_true")
+    
+    parser.add_argument("--batch_size", type=int, default=1) # 20250422 pftq: Batch functionality to avoid reloading the model each video
+    parser.add_argument("--preserve_image_aspect_ratio", action="store_true")  # 20250422 pftq: Avoid resizing
+    
     args = parser.parse_args()
 
     args.model_id = download_model(args.model_id)
     print("model_id:", args.model_id)
 
-    assert (args.use_usp and args.seed is not None) or (not args.use_usp), "usp mode need seed"
-    if args.seed is None:
-        random.seed(time.time())
-        args.seed = int(random.randrange(4294967294))
+    #20250422 pftq: unneeded with seed synchronization code
+    #assert (args.use_usp and args.seed != -1) or (not args.use_usp), "usp mode requires a valid seed"
+
+    local_rank = 0
+    if args.use_usp:
+        from xfuser.core.distributed import initialize_model_parallel, init_distributed_environment
+        import torch.distributed as dist
+
+        dist.init_process_group("nccl")
+        local_rank = dist.get_rank()
+        torch.cuda.set_device(dist.get_rank())
+        device = "cuda"
+
+        init_distributed_environment(rank=dist.get_rank(), world_size=dist.get_world_size())
+
+        initialize_model_parallel(
+            sequence_parallel_degree=dist.get_world_size(),
+            ring_degree=1,
+            ulysses_degree=dist.get_world_size(),
+        )
 
     if args.resolution == "540P":
         height = 544
@@ -64,37 +85,52 @@ if __name__ == "__main__":
     if num_frames > args.base_num_frames:
         assert (
             args.overlap_history is not None
-        ), 'You are supposed to specify the "overlap_history" to support the long video generation. 17 and 37 are recommanded to set.'
+        ), 'You are supposed to specify the "overlap_history" to support the long video generation. 17 and 37 are recommended to set.'
     if args.addnoise_condition > 60:
         print(
-            f'You have set "addnoise_condition" as {args.addnoise_condition}. The value is too large which can cause inconsistency in long video generation. The value is recommanded to set 20.'
+            f'You have set "addnoise_condition" as {args.addnoise_condition}. The value is too large which can cause inconsistency in long video generation. The value is recommended to set 20.'
         )
 
     guidance_scale = args.guidance_scale
     shift = args.shift
-    image = load_image(args.image).convert("RGB") if args.image else None
+    #image = load_image(args.image).convert("RGB") if args.image else None
+
+    #20250422 pftq: Add error handling for image loading, aspect ratio preservation, and multi-GPU synchronization
+    image = None
+    if args.image:
+        if local_rank == 0:
+            try:
+                image = load_image(args.image).convert("RGB")
+
+                # 20250422 pftq: option to preserve image aspect ratio
+                if args.preserve_image_aspect_ratio:
+                    img_width, img_height = image.size
+                    height = int(width / img_width * img_height)
+            except Exception as e:
+                raise ValueError(f"Failed to load or process image: {e}")
+                
+        if args.use_usp:
+            # Broadcast image to other ranks
+            image_data = torch.tensor(np.array(image), dtype=torch.uint8, device="cuda") if image is not None else None
+            if local_rank == 0:
+                dist.broadcast(image_data, src=0)
+            else:
+                image_data = torch.empty((height, width, 3), dtype=torch.uint8, device="cuda")
+                dist.broadcast(image_data, src=0)
+                image = Image.fromarray(image_data.cpu().numpy())
+
+            #20250422 pftq: Broadcast height and width to ensure consistency
+            height_tensor = torch.tensor(height, dtype=torch.int64, device="cuda")
+            width_tensor = torch.tensor(width, dtype=torch.int64, device="cuda")
+            dist.broadcast(height_tensor, src=0)
+            dist.broadcast(width_tensor, src=0)
+            height = height_tensor.item()
+            width = width_tensor.item()
+
     negative_prompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
 
     save_dir = os.path.join("result", args.outdir)
     os.makedirs(save_dir, exist_ok=True)
-    local_rank = 0
-    if args.use_usp:
-        assert not args.prompt_enhancer, "`--prompt_enhancer` is not allowed if using `--use_usp`. We recommend running the skyreels_v2_infer/pipelines/prompt_enhancer.py script first to generate enhanced prompt before enabling the `--use_usp` parameter."
-        from xfuser.core.distributed import initialize_model_parallel, init_distributed_environment
-        import torch.distributed as dist
-
-        dist.init_process_group("nccl")
-        local_rank = dist.get_rank()
-        torch.cuda.set_device(dist.get_rank())
-        device = "cuda"
-
-        init_distributed_environment(rank=dist.get_rank(), world_size=dist.get_world_size())
-
-        initialize_model_parallel(
-            sequence_parallel_degree=dist.get_world_size(),
-            ring_degree=1,
-            ulysses_degree=dist.get_world_size(),
-        )
 
     prompt_input = args.prompt
     if args.prompt_enhancer and args.image is None:
@@ -118,31 +154,70 @@ if __name__ == "__main__":
     if args.causal_attention:
         pipe.transformer.set_ar_attention(args.causal_block_size)
 
-    print(f"prompt:{prompt_input}")
-    print(f"guidance_scale:{guidance_scale}")
+    for idx in range(args.batch_size): # 20250422 pftq: implemented --batch_size
+        if local_rank == 0:
+            print(f"prompt:{prompt_input}")
+            print(f"guidance_scale:{guidance_scale}")
+            print(f"Generating video {idx+1} of {args.batch_size}")
 
-    with torch.cuda.amp.autocast(dtype=pipe.transformer.dtype), torch.no_grad():
-        video_frames = pipe(
-            prompt=prompt_input,
-            negative_prompt=negative_prompt,
-            image=image,
-            height=height,
-            width=width,
-            num_frames=num_frames,
-            num_inference_steps=args.inference_steps,
-            shift=shift,
-            guidance_scale=guidance_scale,
-            generator=torch.Generator(device="cuda").manual_seed(args.seed),
-            overlap_history=args.overlap_history,
-            addnoise_condition=args.addnoise_condition,
-            base_num_frames=args.base_num_frames,
-            ar_step=args.ar_step,
-            causal_block_size=args.causal_block_size,
-            fps=fps,
-        )[0]
+        #20250422 pftq: Synchronize seed across all ranks
+        if args.use_usp:
+            try:
+                #20250422 pftq: Synchronize ranks before seed broadcasting
+                dist.barrier()
 
-    if local_rank == 0:
-        current_time = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
-        video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
-        output_path = os.path.join(save_dir, video_out_file)
-        imageio.mimwrite(output_path, video_frames, fps=fps, quality=8, output_params=["-loglevel", "error"])
+                #20250422 pftq: Always broadcast seed to ensure consistency
+                if local_rank == 0:
+                    if args.seed == -1 or idx > 0:
+                        args.seed = int(random.randrange(4294967294))
+                seed_tensor = torch.tensor(args.seed, dtype=torch.int64, device="cuda")
+                dist.broadcast(seed_tensor, src=0)
+                args.seed = seed_tensor.item()
+
+                #20250422 pftq: Synchronize ranks after seed broadcasting
+                dist.barrier()
+            except Exception as e:
+                print(f"[Rank {local_rank}] Seed broadcasting error: {e}")
+                dist.destroy_process_group()
+                raise
+
+        else:
+            #20250422 pftq: Single GPU seed initialization
+            if args.seed == -1 or idx > 0:
+                args.seed = int(random.randrange(4294967294))
+
+        #20250422 pftq: Set seeds for reproducibility
+        random.seed(args.seed)
+        np.random.seed(args.seed)
+        torch.manual_seed(args.seed)
+        torch.cuda.manual_seed_all(args.seed)
+        
+        with torch.cuda.amp.autocast(dtype=pipe.transformer.dtype), torch.no_grad():
+            video_frames = pipe(
+                prompt=prompt_input,
+                negative_prompt=negative_prompt,
+                image=image,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=args.inference_steps,
+                shift=shift,
+                guidance_scale=guidance_scale,
+                generator=torch.Generator(device="cuda").manual_seed(args.seed),
+                overlap_history=args.overlap_history,
+                addnoise_condition=args.addnoise_condition,
+                base_num_frames=args.base_num_frames,
+                ar_step=args.ar_step,
+                causal_block_size=args.causal_block_size,
+                fps=fps,
+            )[0]
+    
+        if local_rank == 0:
+            current_time = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
+            #video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
+            
+            # 20250422 pftq: more useful filename
+            video_out_file = f"{current_time}_cfg{guidance_scale}_steps{args.inference_steps}_seed{args.seed}_{args.prompt[:100].replace('/','')}_{idx}.mp4"
+            
+            output_path = os.path.join(save_dir, video_out_file)
+            imageio.mimwrite(output_path, video_frames, fps=fps, quality=8, output_params=["-loglevel", "error"])

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -229,7 +229,10 @@ if __name__ == "__main__":
             #video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
             
             # 20250422 pftq: more useful filename
-            video_out_file = f"{current_time}_cfg{guidance_scale}_steps{args.inference_steps}_seed{args.seed}_{args.prompt[:100].replace('/','')}_{idx}.mp4"
+            gpucount = ""
+            if args.use_usp and dist.get_world_size():
+                gpucount = "_"+dist.get_world_size()+"xGPU"
+            video_out_file = f"{current_time}_skyreels2df_cfg{args.guidance_scale}_steps{args.inference_steps}_seed{args.seed}{gpucount}_{args.prompt[:100].replace('/','')}_{idx}.mp4" 
             
             output_path = os.path.join(save_dir, video_out_file)
             imageio.mimwrite(output_path, video_frames, fps=fps, quality=8, output_params=["-loglevel", "error"])

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 
                 #20250422 pftq: Always broadcast seed to ensure consistency
                 if local_rank == 0:
-                    if args.seed == -1 or idx > 0:
+                    if args.seed == -1 or args.seed is None or idx > 0:
                         args.seed = int(random.randrange(4294967294))
                 seed_tensor = torch.tensor(args.seed, dtype=torch.int64, device="cuda")
                 dist.broadcast(seed_tensor, src=0)


### PR DESCRIPTION
I updated the generate_video files to support the following:
- Added seed synchronization code to allow random seed with multi-GPU (https://github.com/SkyworkAI/SkyReels-V2/issues/24).
- Added image broadcast/synchronization to avoid potential sync issues in multi-GPU.
- Added batch_size parameter to allow multiple videos to generate without reloading the model, which takes about 20 min on multi-gpu so this saves a lot of time.
- Added preserve_image_aspect_ratio parameter to allow preserving original image aspect ratio.
- Fixed DF script not resize-cropping the image (I2V script does it but DF is missing the code).
- Exposed negative_prompt to allow that to be changed/overwritten.
- Friendlier filenames with date, seed, cfg, steps, and other details in front.

This brings the flexibility and functionality more in line with Skyreels V1.  I tried to keep the edits minimal and clearly labeled (with old code commented out) so you guys can easily undo specific changes if you want.  I tested with 1 GPU, 2 GPUs, and 8 GPUs on Runpod H100s.

The original inference code still has the issue of multi-GPU initialization taking 20 minutes (https://github.com/SkyworkAI/SkyReels-V2/issues/28), but that would be more complicated a fix so I wanted to push this first to keep the changes clean and organized.  

Let me know if there is anything you guys want changed for the PR.  I still think you guys have the best open-source model so far, just that it's really hard for an average user to get good results without a lot of debugging, so I'm happy to help out.

Example of prompt with the new parameters:
Example prompt (multi-GPU):
```
model_id=Skywork/SkyReels-V2-DF-14B-540P
torchrun --nproc_per_node=2 generate_video_df.py \
  --model_id ${model_id} \
  --resolution 540P \
  --ar_step 0 \
  --base_num_frames 97 \
  --num_frames 257 \
  --overlap_history 17 \
  --inference_steps 50 \
  --guidance_scale 6 \
  --batch_size 10 \
  --preserve_image_aspect_ratio \
  --image "image.jpg" \
  --prompt "" \
  --negative_prompt "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards" \
  --addnoise_condition 20 \
  --use_usp \
  --offload
```

Single GPU:
```
model_id=Skywork/SkyReels-V2-DF-14B-540P
python3 generate_video_df.py \
  --model_id ${model_id} \
  --resolution 540P \
  --ar_step 0 \
  --base_num_frames 97 \
  --num_frames 257 \
  --overlap_history 17 \
  --inference_steps 50 \
  --guidance_scale 6 \
  --batch_size 10 \
  --preserve_image_aspect_ratio \
  --image "image.jpg" \
  --prompt "" \
  --negative_prompt "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards" \
  --addnoise_condition 20 \
  --offload
```