### PR TITLE
Fix filename length issue for long prompts

### DIFF
--- a/generate_video.py
+++ b/generate_video.py
@@ -156,6 +156,8 @@ if __name__ == "__main__":
 
     if local_rank == 0:
         current_time = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
-        video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
+        # Limit filename length and remove special characters
+        safe_prompt = args.prompt[:20].replace('/', '').replace('\\', '').replace(':', '').replace('*', '').replace('?', '').replace('"', '').replace('<', '').replace('>', '').replace('|', '').replace(' ', '_')
+        video_out_file = f"{safe_prompt}_{args.seed}_{current_time}.mp4"
         output_path = os.path.join(save_dir, video_out_file)
         imageio.mimwrite(output_path, video_frames, fps=args.fps, quality=8, output_params=["-loglevel", "error"])

--- a/generate_video_df.py
+++ b/generate_video_df.py
@@ -12,8 +12,8 @@ from skyreels_v2_infer import DiffusionForcingPipeline
 from skyreels_v2_infer.modules import download_model
 from skyreels_v2_infer.pipelines import PromptEnhancer
 from skyreels_v2_infer.pipelines.image2video_pipeline import resizecrop
-from moviepy.editor import VideoFileClip
-
+#from moviepy.editor import VideoFileClip
+from moviepy import *
 
 def get_video_num_frames_moviepy(video_path):
     with VideoFileClip(video_path) as clip:
@@ -215,6 +215,8 @@ if __name__ == "__main__":
 
     if local_rank == 0:
         current_time = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
-        video_out_file = f"{args.prompt[:100].replace('/','')}_{args.seed}_{current_time}.mp4"
+        # Limit filename length and remove special characters
+        safe_prompt = args.prompt[:20].replace('/', '').replace('\\', '').replace(':', '').replace('*', '').replace('?', '').replace('"', '').replace('<', '').replace('>', '').replace('|', '').replace(' ', '_')
+        video_out_file = f"{safe_prompt}_{args.seed}_{current_time}.mp4"
         output_path = os.path.join(save_dir, video_out_file)
         imageio.mimwrite(output_path, video_frames, fps=fps, quality=8, output_params=["-loglevel", "error"])


### PR DESCRIPTION
Reduce prompt limit to 20 chars from 100 to fix 'File name too long' error. Also removes special chars, replaces spaces with underscores. Applied to generate_video.py & generate_video_df.py.Fix 'no module named moviepy.editor' error.
![image](https://github.com/user-attachments/assets/f3adcf00-7360-456c-ba50-b1751bd0d374)